### PR TITLE
Potential fix for code scanning alert no. 3: Shell command built from environment values

### DIFF
--- a/user-workspace/ai-cli-tool/scripts/create-installer.js
+++ b/user-workspace/ai-cli-tool/scripts/create-installer.js
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -68,7 +68,7 @@ async function createInstaller() {
     await fs.writeFile(INSTALLER_CONFIG, nsisScript);
     
     // Run NSIS compiler
-    execSync(`makensis ${INSTALLER_CONFIG}`, { stdio: 'inherit' });
+    execFileSync('makensis', [INSTALLER_CONFIG], { stdio: 'inherit' });
     
     console.log('Installer created successfully!');
   } catch (error) {


### PR DESCRIPTION
Potential fix for [https://github.com/CrzyHAX91/Smart-CLI/security/code-scanning/3](https://github.com/CrzyHAX91/Smart-CLI/security/code-scanning/3)

To fix the problem, we should avoid constructing the shell command dynamically with potentially unsafe input. Instead, we can use the `execFileSync` function, which allows us to pass arguments to the command separately, ensuring that they are not interpreted by the shell.

- Replace the `execSync` call with `execFileSync`.
- Pass the `INSTALLER_CONFIG` as an argument to the `makensis` command.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
