### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
     - uses: actions/checkout@v4
@@ -49,6 +51,9 @@ jobs:
 
   security_scan:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    
     steps:
     - uses: actions/checkout@v4
     
@@ -93,6 +98,9 @@ jobs:
     needs: [test, security_scan]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      actions: write
     
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/CrzyHAX91/Smart-CLI/security/code-scanning/19](https://github.com/CrzyHAX91/Smart-CLI/security/code-scanning/19)

To fix the issue, we will add explicit `permissions` blocks to the workflow. Each job will be assigned the least privileges required to complete its tasks:

1. **`test` and `security_scan` jobs:** These jobs only need read access to the repository contents (`contents: read`).
2. **`release` job:** This job requires write access to `contents` for tagging and pushing releases, and `actions: write` for creating a release.

The `permissions` block will be added to each job to ensure that the `GITHUB_TOKEN` is limited to the required scope.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
