### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -18,6 +18,10 @@
 
 name: "Microsoft Defender For Devops"
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/CrzyHAX91/Smart-CLI/security/code-scanning/4](https://github.com/CrzyHAX91/Smart-CLI/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow:
1. The `actions/checkout` action requires `contents: read` to check out the repository code.
2. The `github/codeql-action/upload-sarif` action may require `security-events: write` to upload SARIF files to the Security tab.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `MSDO` job. In this case, we will add it at the root level for simplicity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
